### PR TITLE
Remove trailing slash from base request URL to avoid OAuth errors.

### DIFF
--- a/lib/woocommerce-api/class-wc-api-client-authentication.php
+++ b/lib/woocommerce-api/class-wc-api-client-authentication.php
@@ -76,7 +76,7 @@ class WC_API_Client_Authentication {
 	 */
 	public function generate_oauth_signature( $params, $http_method ) {
 
-		$base_request_uri = rawurlencode( $this->url );
+		$base_request_uri = rawurlencode( rtrim( $this->url, '/' ) );
 
 		// normalize parameter key/values and sort them
 		$params = $this->normalize_parameters( $params );


### PR DESCRIPTION
I was getting "Invalid Signature - provided signature does not match" errors when trying to fetch orders via $client->orders->get(). Comparing the signature strings used by the client library and WooCommerce itself, I saw the difference in the trailing slash. This change fixed the issue for me.