### PR TITLE
Create autoload entries for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
             "name": "Gerhard Potgieter"
         }
     ],
+    autoload: {
+        "files": ["lib/woocommerce-api.php"]
+    },
     "minimum-stability": "stable",
     "require": {}
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
         }
     ],
     "autoload": {
-        "files": ["lib/woocommerce-api.php"],
         "classmap": ["lib/woocommerce-api"]
     },
     "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         }
     ],
     "autoload": {
-        "files": ["lib/woocommerce-api.php"]
+        "files": ["lib/woocommerce-api.php"],
+        "classmap": ["lib/woocommerce-api"]
     },
     "minimum-stability": "stable",
     "require": {}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
             "name": "Gerhard Potgieter"
         }
     ],
-    autoload: {
+    "autoload": {
         "files": ["lib/woocommerce-api.php"]
     },
     "minimum-stability": "stable",

--- a/example/composer-example.php
+++ b/example/composer-example.php
@@ -1,0 +1,35 @@
+<?php
+
+use WC_API_Client;
+use WC_API_Client_Exception;
+
+$options = array(
+    'debug'           => true,
+    'return_as_array' => false,
+    'validate_url'    => false,
+    'timeout'         => 30,
+    'ssl_verify'      => false,
+);
+
+try {
+    $client = new WC_API_Client(
+        'http://your-store-url.com',
+        'ck_enter_your_consumer_key',
+        'cs_enter_your_consumer_secret',
+        $options
+    );
+
+    // index
+    //print_r($client->index->get());
+    
+    // For other endpoints, see example.php
+    
+} catch (WC_API_Client_Exception $e) {
+    echo $e->getMessage() . PHP_EOL;
+    echo $e->getCode() . PHP_EOL;
+
+    if ($e instanceof WC_API_Client_HTTP_Exception) {
+        print_r($e->get_request());
+        print_r($e->get_response());
+    }
+}

--- a/example/composer-example.php
+++ b/example/composer-example.php
@@ -1,4 +1,4 @@
-<?php
+<?php // Root namespace for now. See Issue #85
 
 use WC_API_Client;
 use WC_API_Client_Exception;

--- a/lib/woocommerce-api.php
+++ b/lib/woocommerce-api.php
@@ -8,15 +8,6 @@
 
 $dir = dirname( __FILE__ ) . '/woocommerce-api/';
 
-// required functions
-if ( ! extension_loaded( 'curl' ) ) {
-	throw new Exception( 'WooCommerce REST API client requires the cURL PHP extension.' );
-}
-
-if ( ! extension_loaded( 'json' ) ) {
-	throw new Exception( 'WooCommerce REST API client needs the JSON extension.' );
-}
-
 // base class
 require_once( $dir . 'class-wc-api-client.php' );
 

--- a/lib/woocommerce-api/class-wc-api-client.php
+++ b/lib/woocommerce-api/class-wc-api-client.php
@@ -81,6 +81,15 @@ class WC_API_Client {
 	 */
 	public function __construct( $store_url, $consumer_key, $consumer_secret, $options = array() ) {
 
+		// required functions
+		if ( ! extension_loaded( 'curl' ) ) {
+			throw new Exception( 'WooCommerce REST API client requires the cURL PHP extension.' );
+		}
+
+		if ( ! extension_loaded( 'json' ) ) {
+			throw new Exception( 'WooCommerce REST API client needs the JSON extension.' );
+		}
+
 		// set required info
 		$this->store_url = $store_url;
 		$this->consumer_key = $consumer_key;


### PR DESCRIPTION
When used in a composer-based application (e.g. Laravel) these changes will ensure the classes are available to the application. There are two methods used here - you may want them both, or just one or the other. Here is how they work:

* The `autoload/files` entry is the equivalent to an `include`. It will load the main bootstrap file in this package on every page load. Loading that bootstrap file will then load all the classes in the package, again, on every page load.
* The `autoload\classmap` takes a different approach. This will scan the package for php scripts, then extract all the classes it finds, and sets up a register of where all those classes are. When any of those classes are used, the composer autoloader will kick in and load the appropriate file. The classes will only be loaded when they are actually used. It will load the classes in the order they are used, and will not attempt to load the bootstrap file first, since it has no need for the bootstrap file.

So, the first method has an overhead on pages the package is not needed, but it will execute everything that the package is expecting to be loaded and in the right order. The second method is more efficient, only loading classes as they are needed and used (down to individual classes - if you don't access the projects resource, then that class is not loaded), but will skip the bootstrap script that may have some logic in that you are expecting to be run.

Personally, I would go for the classmap approach, so long as you are happy that not running the bootstrap file will be okay, perhaps removing some logic from the bootstrap `lib/woocommerce-api.php` script. Both methods are in here, but I can remove either, or we can leave both in and decide later.