### PR TITLE
Add HTTP Basic Auth support

### DIFF
--- a/lib/woocommerce-api/class-wc-api-client-http-request.php
+++ b/lib/woocommerce-api/class-wc-api-client-http-request.php
@@ -65,6 +65,10 @@ class WC_API_Client_HTTP_Request {
 
 		$this->ch = curl_init();
 
+        if($args['options']['httpauth_user'] !== null) {
+            curl_setopt($this->ch, CURLOPT_USERPWD, $args['options']['httpauth_user'] . ":" . $args['options']['httpauth_pass']);
+        }
+		
 		// default cURL opts
 		curl_setopt( $this->ch, CURLOPT_SSL_VERIFYPEER, $ssl_verify );
 		curl_setopt( $this->ch, CURLOPT_SSL_VERIFYHOST, $ssl_verify );

--- a/lib/woocommerce-api/class-wc-api-client-http-request.php
+++ b/lib/woocommerce-api/class-wc-api-client-http-request.php
@@ -65,9 +65,9 @@ class WC_API_Client_HTTP_Request {
 
 		$this->ch = curl_init();
 
-        if($args['options']['httpauth_user'] !== null) {
-            curl_setopt($this->ch, CURLOPT_USERPWD, $args['options']['httpauth_user'] . ":" . $args['options']['httpauth_pass']);
-        }
+		if($args['options']['httpauth_username'] !== null) {
+			curl_setopt($this->ch, CURLOPT_USERPWD, $args['options']['httpauth_username'] . ":" . $args['options']['httpauth_password']);
+		}
 		
 		// default cURL opts
 		curl_setopt( $this->ch, CURLOPT_SSL_VERIFYPEER, $ssl_verify );

--- a/lib/woocommerce-api/class-wc-api-client.php
+++ b/lib/woocommerce-api/class-wc-api-client.php
@@ -37,6 +37,12 @@ class WC_API_Client {
 	/** @var bool true to perform SSL peer verification */
 	public $ssl_verify = true;
 
+	/** @var null|string if set, used for HTTP BASIC AUTH */
+	public $httpauth_user = null;
+
+	/** @var null|string if set, used for HTTP BASIC AUTH */
+	public $httpauth_pass = null;
+	
 	/** Resources */
 
 	/** @var WC_API_Client_Resource_Coupons instance */
@@ -191,6 +197,8 @@ class WC_API_Client {
 			'validate_url',
 			'timeout',
 			'ssl_verify',
+            'httpauth_user',
+            'httpauth_pass',
 		);
 
 		foreach ( (array) $options as $opt_key => $opt_value ) {
@@ -218,7 +226,17 @@ class WC_API_Client {
 	 */
 	public function validate_api_url() {
 
-		$index = @file_get_contents( $this->api_url );
+        if($this->httpauth_user !== null) {
+            $context = stream_context_create(array(
+                'http' => array(
+                    'header'  => "Authorization: Basic " . base64_encode($this->httpauth_user.':'.$this->httpauth_pass)
+                )
+            ));
+
+            $index = @file_get_contents( $this->api_url, false, $context);
+        } else {
+            $index = @file_get_contents( $this->api_url);
+        }
 
 		// check for HTTP 404 response (file_get_contents() returns false when encountering 404)
 		// this usually means:
@@ -278,6 +296,8 @@ class WC_API_Client {
 				'ssl_verify'  => $this->ssl_verify,
 				'json_decode' => $this->return_as_array ? 'array' : 'object',
 				'debug'       => $this->debug,
+                'httpauth_user' => $this->httpauth_user,
+                'httpauth_pass' => $this->httpauth_pass,
 			)
 		);
 

--- a/lib/woocommerce-api/class-wc-api-client.php
+++ b/lib/woocommerce-api/class-wc-api-client.php
@@ -197,8 +197,8 @@ class WC_API_Client {
 			'validate_url',
 			'timeout',
 			'ssl_verify',
-            'httpauth_user',
-            'httpauth_pass',
+			'httpauth_user',
+			'httpauth_pass',
 		);
 
 		foreach ( (array) $options as $opt_key => $opt_value ) {
@@ -226,12 +226,12 @@ class WC_API_Client {
 	 */
 	public function validate_api_url() {
 
-        if($this->httpauth_user !== null) {
-            $context = stream_context_create(array(
-                'http' => array(
-                    'header'  => "Authorization: Basic " . base64_encode($this->httpauth_user.':'.$this->httpauth_pass)
-                )
-            ));
+		if($this->httpauth_user !== null) {
+			$context = stream_context_create(array(
+				'http' => array(
+					'header'  => "Authorization: Basic " . base64_encode($this->httpauth_user.':'.$this->httpauth_pass)
+				)
+			));
 
             $index = @file_get_contents( $this->api_url, false, $context);
         } else {
@@ -296,8 +296,8 @@ class WC_API_Client {
 				'ssl_verify'  => $this->ssl_verify,
 				'json_decode' => $this->return_as_array ? 'array' : 'object',
 				'debug'       => $this->debug,
-                'httpauth_user' => $this->httpauth_user,
-                'httpauth_pass' => $this->httpauth_pass,
+				'httpauth_user' => $this->httpauth_user,
+				'httpauth_pass' => $this->httpauth_pass,
 			)
 		);
 

--- a/lib/woocommerce-api/class-wc-api-client.php
+++ b/lib/woocommerce-api/class-wc-api-client.php
@@ -38,10 +38,10 @@ class WC_API_Client {
 	public $ssl_verify = true;
 
 	/** @var null|string if set, used for HTTP BASIC AUTH */
-	public $httpauth_user = null;
+	public $httpauth_username = null;
 
 	/** @var null|string if set, used for HTTP BASIC AUTH */
-	public $httpauth_pass = null;
+	public $httpauth_password = null;
 	
 	/** Resources */
 
@@ -197,8 +197,8 @@ class WC_API_Client {
 			'validate_url',
 			'timeout',
 			'ssl_verify',
-			'httpauth_user',
-			'httpauth_pass',
+			'httpauth_username',
+			'httpauth_password',
 		);
 
 		foreach ( (array) $options as $opt_key => $opt_value ) {
@@ -226,10 +226,10 @@ class WC_API_Client {
 	 */
 	public function validate_api_url() {
 
-		if($this->httpauth_user !== null) {
+		if($this->httpauth_username !== null) {
 			$context = stream_context_create(array(
 				'http' => array(
-					'header'  => "Authorization: Basic " . base64_encode($this->httpauth_user.':'.$this->httpauth_pass)
+					'header'  => "Authorization: Basic " . base64_encode($this->httpauth_username.':'.$this->httpauth_password)
 				)
 			));
 
@@ -296,8 +296,8 @@ class WC_API_Client {
 				'ssl_verify'  => $this->ssl_verify,
 				'json_decode' => $this->return_as_array ? 'array' : 'object',
 				'debug'       => $this->debug,
-				'httpauth_user' => $this->httpauth_user,
-				'httpauth_pass' => $this->httpauth_pass,
+				'httpauth_username' => $this->httpauth_username,
+				'httpauth_password' => $this->httpauth_password,
 			)
 		);
 


### PR DESCRIPTION
Hy,

During setup of a new shop HTTP Basic Authentication is active in some case.
This modification implement the HTTP Basic Authentication to allow the usage of the REST API also within such setup.
It is already tested in my agency. I only change code formatting.

If you find it useful, feel free to implement the code.
If not, I will understand if the situation is too special to implement globally.

Stefan
